### PR TITLE
Support SSMS22

### DIFF
--- a/src/SQLScriptsExplorer.Addin/SQLScriptsExplorer.Addin.csproj
+++ b/src/SQLScriptsExplorer.Addin/SQLScriptsExplorer.Addin.csproj
@@ -43,7 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CopyVsixExtensionFiles>True</CopyVsixExtensionFiles>
-    <CopyVsixExtensionLocation>C:\Program Files\Microsoft SQL Server Management Studio 21\Release\Common7\IDE\Extensions\SQLScriptsExplorer</CopyVsixExtensionLocation>
+    <CopyVsixExtensionLocation>C:\Program Files\Microsoft SQL Server Management Studio 22\Release\Common7\IDE\Extensions\SQLScriptsExplorer</CopyVsixExtensionLocation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,7 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CopyVsixExtensionFiles>True</CopyVsixExtensionFiles>
-    <CopyVsixExtensionLocation>C:\Program Files %28x86%29\Microsoft SQL Server Management Studio 18\Common7\IDE\Extensions\SQLScriptsExplorer</CopyVsixExtensionLocation>
+    <CopyVsixExtensionLocation>C:\Program Files\Microsoft SQL Server Management Studio 22\Release\Common7\IDE\Extensions\SQLScriptsExplorer</CopyVsixExtensionLocation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Controls\HighlightTextBlock.cs" />

--- a/src/SQLScriptsExplorer.Addin/source.extension.vsixmanifest
+++ b/src/SQLScriptsExplorer.Addin/source.extension.vsixmanifest
@@ -1,27 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="SQLScriptsExplorer.Addin.b22c3965-9172-4eab-980d-a833bee345ab" Version="1.0" Language="en-US" Publisher="Joao Ribeiro Neto" />
-    <DisplayName>SQL Scripts Explorer Addin.</DisplayName>
-    <Description>Collaborate SQL Scripts between teams.</Description>
-  </Metadata>
-  <Installation AllUsers="true">
-    <InstallationTarget Id="ssms" Version="[13.0,)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[13.0,)" Id="Microsoft.VisualStudio.IntegratedShell">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.8.1,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.16.0" DisplayName="Visual Studio MPF 16.0" d:Source="Installed" Version="[16.0,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
+	<Metadata>
+		<Identity Id="SQLScriptsExplorer.Addin.b22c3965-9172-4eab-980d-a833bee345ab" Version="1.0" Language="en-US" Publisher="Joao Ribeiro Neto" />
+		<DisplayName>SQL Scripts Explorer Addin.</DisplayName>
+		<Description>Collaborate SQL Scripts between teams.</Description>
+	</Metadata>
+	<Installation AllUsers="true">
+		<!-- SSMS 13–18 (32-bit) -->
+		<InstallationTarget Id="ssms" Version="[13.0, 18.0)">
+			<ProductArchitecture>x86</ProductArchitecture>
+		</InstallationTarget>
 
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+		<!-- SSMS 19+ (64-bit) -->
+		<InstallationTarget Version="[21.0,)" Id="Microsoft.VisualStudio.Ssms">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.8,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.16.0" DisplayName="Visual Studio MPF 16.0" d:Source="Installed" Version="[16.0,)" />
+	</Dependencies>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 </PackageManifest>


### PR DESCRIPTION
- chore(build): update VSIX copy path to SSMS 22 directory
- feat(manifest): update SSMS targets

Updated installation targets to support both SSMS 13–18 (32-bit) and SSMS 19+ (64-bit). Changed .NET Framework dependency from [4.8.1,) to [4.8,) to resolve a Microsoft VSIX bug/quirk that doesn't recognize the patch number, breaking the VSIX installer. Removed IntegratedShell target as it seemed to prevent the SQL Script Explorer from showing in the view toolbar for me, YMMV.